### PR TITLE
fix(zsh): autoload compinit and reject empty zcompdump cache

### DIFF
--- a/zsh/conf.d/20-completion.zsh
+++ b/zsh/conf.d/20-completion.zsh
@@ -2,12 +2,14 @@
 
 ## Completion initialisation — called deferred by sheldon (after zsh-completions
 ## populates fpath, before fzf-tab wraps widgets).
+autoload -Uz compinit
 _compinit_load() {
   local dump="${XDG_CACHE_HOME}/zsh/zcompdump"
   mkdir -p "${dump:h}"
-  # Skip the slow per-directory security check when the dump is < 24 h old.
-  # Use full compinit (with security checks) to rebuild when stale or missing.
-  if [[ -f $dump && -n ${dump}(#qNmh-24) ]]; then
+  # Skip the slow per-directory security check when the dump is fresh (< 24 h)
+  # and non-empty. Rebuild otherwise — an empty dump (e.g. from a previously
+  # failed compinit run) silently loads nothing and breaks every completer.
+  if [[ -s $dump && -n ${dump}(#qNmh-24) ]]; then
     compinit -C -d "$dump"
   else
     compinit -d "$dump"


### PR DESCRIPTION
Two regressions from 09d6815 broke tab completion:

1. `compinit` is a function from fpath, not a builtin; the refactor dropped its `autoload -Uz compinit` so every deferred `_compinit_load` call failed with `command not found`, silently leaving no completers registered.

2. The fast-path check `[[ -f $dump && -n ${dump}(#qNmh-24) ]]` accepted a 0-byte dump (left behind by the failing run above) as fresh, then `compinit -C` loaded that empty dump on every subsequent shell — permanently wedging completion until the file was deleted manually. Switching `-f` to `-s` forces a rebuild when the dump is empty.

Symptoms were `_ftb__main_complete:104: permission denied:` followed by
`command not found: _list / _oldlist / _expand / ...` on every tab.