### PR TITLE
fix(gpg): restore gpg-agent as the ssh agent

### DIFF
--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -25,6 +25,7 @@
 
 [bin]
   [bin.files]
+  "bin/pinentry-auto"  = "~/.local/bin/pinentry-auto"
   "bin/transcode-hevc" = "~/.local/bin/transcode-hevc"
   "bin/update"         = "~/.local/bin/update"
 

--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -90,6 +90,11 @@
   "gpg/gpg-agent.conf" = "~/.local/share/gnupg/gpg-agent.conf"
   "gpg/sshcontrol"     = "~/.local/share/gnupg/sshcontrol"
 
+  "gpg/systemd/gpg-agent-browser.socket.conf" = "~/.config/systemd/user/gpg-agent-browser.socket.d/gnupghome.conf"
+  "gpg/systemd/gpg-agent-extra.socket.conf"   = "~/.config/systemd/user/gpg-agent-extra.socket.d/gnupghome.conf"
+  "gpg/systemd/gpg-agent-ssh.socket.conf"     = "~/.config/systemd/user/gpg-agent-ssh.socket.d/gnupghome.conf"
+  "gpg/systemd/gpg-agent.socket.conf"         = "~/.config/systemd/user/gpg-agent.socket.d/gnupghome.conf"
+
 [kitty]
   [kitty.files]
   "kitty/dark.theme.conf"  = "~/.config/kitty/dark.theme.conf"

--- a/bin/pinentry-auto
+++ b/bin/pinentry-auto
@@ -1,11 +1,30 @@
 #!/bin/sh
+## Each interactive SSH session drops a file named after its shell's PID into
+## this directory to request a terminal prompt instead of a dialog on the
+## desktop, which nobody is sitting in front of.  Sessions remove their own
+## file on exit, but a killed shell never runs its trap, so presence alone is
+## not evidence of a live session: an entry counts only while its process is
+## still alive, and dead ones are reaped here.
 _ssh_dir="${XDG_RUNTIME_DIR:-$HOME/.cache}/pinentry-ssh"
-if [ -d "$_ssh_dir" ] && [ -n "$(ls -A "$_ssh_dir" 2>/dev/null)" ]; then
-    exec /usr/bin/pinentry-curses "$@"
+_ssh_active=0
+
+if [ -d "$_ssh_dir" ]; then
+  for _flag in "$_ssh_dir"/*; do
+    [ -e "$_flag" ] || continue
+    if kill -0 "${_flag##*/}" 2>/dev/null; then
+      _ssh_active=1
+    else
+      rm -f "$_flag"
+    fi
+  done
+fi
+
+if [ "$_ssh_active" -eq 1 ]; then
+  exec /usr/bin/pinentry-curses "$@"
 elif [ -n "$WAYLAND_DISPLAY" ]; then
-    exec /usr/bin/pinentry-gnome3 "$@"
+  exec /usr/bin/pinentry-gnome3 "$@"
 elif [ -n "$DISPLAY" ]; then
-    exec /usr/bin/pinentry-gtk "$@"
+  exec /usr/bin/pinentry-gtk "$@"
 else
-    exec /usr/bin/pinentry-curses "$@"
+  exec /usr/bin/pinentry-curses "$@"
 fi

--- a/bin/pinentry-auto
+++ b/bin/pinentry-auto
@@ -1,0 +1,11 @@
+#!/bin/sh
+_ssh_dir="${XDG_RUNTIME_DIR:-$HOME/.cache}/pinentry-ssh"
+if [ -d "$_ssh_dir" ] && [ -n "$(ls -A "$_ssh_dir" 2>/dev/null)" ]; then
+    exec /usr/bin/pinentry-curses "$@"
+elif [ -n "$WAYLAND_DISPLAY" ]; then
+    exec /usr/bin/pinentry-gnome3 "$@"
+elif [ -n "$DISPLAY" ]; then
+    exec /usr/bin/pinentry-gtk "$@"
+else
+    exec /usr/bin/pinentry-curses "$@"
+fi

--- a/gpg/gpg-agent.conf
+++ b/gpg/gpg-agent.conf
@@ -5,4 +5,6 @@ enable-ssh-support
 
 {{#if (is_executable "/opt/homebrew/bin/pinentry-mac") }}
 pinentry-program /opt/homebrew/bin/pinentry-mac
+{{else}}
+pinentry-program ~/.local/bin/pinentry-auto
 {{/if}}

--- a/gpg/systemd/gpg-agent-browser.socket.conf
+++ b/gpg/systemd/gpg-agent-browser.socket.conf
@@ -1,0 +1,6 @@
+## See gpg-agent.socket.conf for why the socket path is hashed.
+##
+## Regenerate the path with: gpgconf --list-dirs agent-browser-socket
+[Socket]
+ListenStream=
+ListenStream=%t/gnupg/d.kzge3rbrzdd3u1q6rx3ujnqj/S.gpg-agent.browser

--- a/gpg/systemd/gpg-agent-extra.socket.conf
+++ b/gpg/systemd/gpg-agent-extra.socket.conf
@@ -1,0 +1,6 @@
+## See gpg-agent.socket.conf for why the socket path is hashed.
+##
+## Regenerate the path with: gpgconf --list-dirs agent-extra-socket
+[Socket]
+ListenStream=
+ListenStream=%t/gnupg/d.kzge3rbrzdd3u1q6rx3ujnqj/S.gpg-agent.extra

--- a/gpg/systemd/gpg-agent-ssh.socket.conf
+++ b/gpg/systemd/gpg-agent-ssh.socket.conf
@@ -1,0 +1,12 @@
+## See gpg-agent.socket.conf for why the socket path is hashed.
+##
+## ExecStartPost publishes SSH_AUTH_SOCK into the systemd user manager
+## environment so that graphical applications — which never source the shell
+## config — also reach gpg-agent rather than whichever agent claimed the
+## variable first.
+##
+## Regenerate the path with: gpgconf --list-dirs agent-ssh-socket
+[Socket]
+ListenStream=
+ListenStream=%t/gnupg/d.kzge3rbrzdd3u1q6rx3ujnqj/S.gpg-agent.ssh
+ExecStartPost=-/usr/bin/systemctl --user set-environment SSH_AUTH_SOCK=%t/gnupg/d.kzge3rbrzdd3u1q6rx3ujnqj/S.gpg-agent.ssh

--- a/gpg/systemd/gpg-agent.socket.conf
+++ b/gpg/systemd/gpg-agent.socket.conf
@@ -1,0 +1,9 @@
+## GNUPGHOME is not ~/.gnupg, so gpg places its sockets in a per-homedir
+## subdirectory of the runtime dir (d.<z-base-32 hash of the homedir path>)
+## rather than directly under /run/user/$UID/gnupg.  The units shipped by gnupg
+## only know the unhashed path, so socket activation never fires without this.
+##
+## Regenerate the path with: gpgconf --list-dirs agent-socket
+[Socket]
+ListenStream=
+ListenStream=%t/gnupg/d.kzge3rbrzdd3u1q6rx3ujnqj/S.gpg-agent

--- a/zsh/conf.d/45-gpg.zsh
+++ b/zsh/conf.d/45-gpg.zsh
@@ -1,0 +1,24 @@
+# shellcheck shell=zsh
+
+## GPG agent — TTY and SSH socket
+##
+## GPG_TTY is read by gpg and sent to gpg-agent as OPTION ttyname= with each
+## request, so pinentry-curses knows which terminal to open.  updatestartuptty
+## sets the same info as gpg-agent's fallback for callers that don't send it
+## (e.g. GUI tools, agents not invoked through the gpg binary).
+export GPG_TTY=$TTY
+export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket 2>/dev/null)
+gpg-connect-agent updatestartuptty /bye &>/dev/null
+
+## When connecting via SSH, drop a flag file so pinentry-auto uses curses
+## instead of opening a GUI dialog on the unattended local display.
+## A per-session file under a lock directory lets multiple concurrent SSH
+## sessions coexist: the flag persists until every session has exited.
+if [[ -n $SSH_CONNECTION ]]; then
+    _pinentry_ssh_dir="${XDG_RUNTIME_DIR:-$HOME/.cache}/pinentry-ssh"
+    _pinentry_ssh_flag="$_pinentry_ssh_dir/$$"
+    mkdir -p "$_pinentry_ssh_dir"
+    touch "$_pinentry_ssh_flag"
+    trap 'rm -f "$_pinentry_ssh_flag"; rmdir "$_pinentry_ssh_dir" 2>/dev/null' EXIT
+    unset _pinentry_ssh_dir _pinentry_ssh_flag
+fi


### PR DESCRIPTION
## Problem

Three faults left `gpg-agent` unusable as the SSH agent, requiring it to be
launched by hand while GNOME's agent won everywhere else.

**Socket activation could never fire.** `GNUPGHOME` is `$XDG_DATA_HOME/gnupg`,
not `~/.gnupg`. Because that homedir is non-default, gpg ≥ 2.1 places its
sockets in a hashed subdirectory of the runtime dir:

```
/run/user/1000/gnupg/d.kzge3rbrzdd3u1q6rx3ujnqj/S.gpg-agent.ssh
```

The units shipped by gnupg hardcode the unhashed path
(`ListenStream=%t/gnupg/S.gpg-agent`), so they were listening on paths nothing
ever connected to. Commit signing still worked, because the `gpg` binary
auto-launches its own agent on demand; `ssh` does not — it only connects to
`$SSH_AUTH_SOCK`.

**GNOME claimed `SSH_AUTH_SOCK`.** `gcr-4` 4.4 ships `gcr-ssh-agent.socket`,
enabled by preset, which publishes its own socket into the systemd user
manager environment:

```ini
ExecStartPost=-/usr/bin/systemctl --user set-environment SSH_AUTH_SOCK=%t/gcr/ssh
```

Only `zsh/conf.d/45-gpg.zsh` overrode this, so interactive shells were fine but
everything launched by the user manager — graphical applications included —
reached GNOME's agent instead.

**`pinentry-auto` always chose curses.** An SSH session announces itself by
dropping a file named after its shell's PID into
`$XDG_RUNTIME_DIR/pinentry-ssh`, removed again by a trap on exit. A killed
shell never runs that trap, so the files accumulate — 26 had built up over
three days. Their presence alone routed every prompt to `pinentry-curses`,
which cannot prompt from a systemd-supervised agent, so unlocking a key in the
desktop session failed with `agent refused operation`.

## Change

Drop-ins under `gpg/systemd/`, deployed to
`~/.config/systemd/user/<unit>.socket.d/gnupghome.conf`:

- All four sockets (`gpg-agent`, `-ssh`, `-extra`, `-browser`) have
  `ListenStream` reset to the path gpg actually uses.
- `gpg-agent-ssh.socket` publishes `SSH_AUTH_SOCK` into the user manager
  environment, so graphical applications agree with the shell. This is the same
  mechanism gcr was using.

They live under the `gpg` package rather than `sway`, since they are unrelated
to the window manager.

`bin/pinentry-auto` now treats a flag file as evidence of a session only while
its process is still alive, reaping dead entries as it goes. The terminal
prompt is still chosen whenever a real SSH session is attached, which is the
point of the split.

## Verification

```
ssh-add -l                                   → 3 keys, exit 0
systemctl --user is-active gpg-agent.service → active
pgrep -a gpg-agent                           → /usr/bin/gpg-agent --supervised
gpg --clearsign                              → exit 0
git push                                     → exit 0, GUI prompt in session
```

Sockets are mode `0600` (systemd-owned) rather than `0700`, confirming the
agent is socket-activated rather than self-launched. `pinentry-auto` was
exercised against a dead PID (reaped, GUI chosen), a live PID (curses chosen)
and an empty directory (GUI chosen).

## Not captured here

- **`systemctl --user mask gcr-ssh-agent.socket gcr-ssh-agent.service`** is
  required, and is system state rather than configuration. Masking rather than
  disabling, because the preset re-enables it on upgrade. This must be re-run
  when rebuilding a machine.
- **The hashed path is baked into the drop-ins.** It derives from the
  `GNUPGHOME` string, so it holds wherever `$HOME` is `/home/josh` but will
  break elsewhere. Each file carries the `gpgconf --list-dirs` invocation that
  regenerates it.
- **`gpg-agent-extra.socket` is `static`** and in no `sockets.target.wants`, so
  it does not start at boot. Its drop-in is correct but inert unless it is
  pulled in explicitly.
- **PID reuse** could in principle make a recycled PID look like a live SSH
  session. The window is small and the failure mode is the old behaviour, so it
  is left alone.
