### PR TITLE
feat(update): pull and deploy dotfiles first

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -10,6 +10,59 @@ check_command() {
 }
 
 ################################################################################
+## Dotfiles
+################################################################################
+
+## Bash reads a script in chunks as it runs rather than loading it up front, so
+## rewriting this file mid-run leaves it resuming from a stale byte offset and
+## executing whatever now sits there. Refresh the checkout before anything else
+## and hand over to the new copy immediately; UPDATE_REEXEC keeps that handover
+## from looping.
+
+dotfiles="${DOTFILES_DIR:-$HOME/.dotfiles}"
+
+if [ -z "${UPDATE_REEXEC:-}" ]; then
+  if ! check_command "git"; then
+    echo "update: git is unavailable, cannot refresh $dotfiles" >&2
+    exit 1
+  fi
+
+  if ! git -C "$dotfiles" rev-parse --git-dir &>/dev/null; then
+    echo "update: $dotfiles is not a git checkout" >&2
+    exit 1
+  fi
+
+  if ! git -C "$dotfiles" pull --rebase --autostash; then
+    echo "update: could not refresh $dotfiles, resolve the checkout by hand" >&2
+    exit 1
+  fi
+
+  ## The pull reports success even when reapplying the autostash conflicts,
+  ## which leaves conflict markers sitting in the working tree. Deploying that
+  ## would scatter them across the live config, so stop while it is still one
+  ## checkout to repair rather than a machine to unpick.
+  if [ -n "$(git -C "$dotfiles" ls-files --unmerged)" ]; then
+    echo "update: $dotfiles has unresolved conflicts, resolve them by hand" >&2
+    exit 1
+  fi
+
+  UPDATE_REEXEC=1 exec "$dotfiles/bin/update" "$@"
+fi
+
+## Only reachable through the handover above, so the checkout is current and the
+## deployed copies can be brought into line with it. A missing dotter is left to
+## the mise run further down, which is what installs it in the first place.
+
+if check_command "dotter"; then
+  if ! (cd "$dotfiles" && dotter deploy); then
+    echo "update: dotter deploy failed" >&2
+    exit 1
+  fi
+else
+  echo "update: dotter is unavailable, skipping deploy" >&2
+fi
+
+################################################################################
 ## System
 ################################################################################
 


### PR DESCRIPTION
## Problem

`update` upgraded every tool on the machine but never touched the checkout that
configures them, so a run could leave the tools current and the configuration
several commits behind. Pulling and deploying is the obvious companion step —
but doing it naively from inside the script being updated is unsafe.

Bash reads a script in chunks as it executes, keeping a byte offset into the
file rather than loading it whole. A pull that rewrites `bin/update` mid-run
therefore leaves bash resuming from a stale offset and executing whatever now
occupies that position — increasingly likely the more the file's length
changes.

## Change

The refresh is now the first thing that runs, ahead of the package managers and
well ahead of mise:

1. Verify `git` is available and `$DOTFILES_DIR` (default `~/.dotfiles`) is a
   checkout.
2. `git pull --rebase --autostash`.
3. Check for unresolved paths — see below.
4. `exec` into the refreshed copy, guarded by `UPDATE_REEXEC` against looping.
5. In the second pass, `dotter deploy` from the repository root.

Any failure in steps 1–3 aborts the whole run before a single package is
touched.

### `git pull` reports success on a conflicting autostash

Guarding on the pull's exit status is not sufficient, which is not obvious and
was caught only by testing it:

```
Your local changes are stashed, however applying them
resulted in conflicts. [...]
pull exit=0
```

The working tree is left mid-rebase with conflict markers in it, and `$?` is
still `0`. Deploying at that point would scatter those markers across the live
configuration, so unresolved paths are checked for explicitly:

```bash
if [ -n "$(git -C "$dotfiles" ls-files --unmerged)" ]; then
  echo "update: $dotfiles has unresolved conflicts, resolve them by hand" >&2
  exit 1
fi
```

This is not hypothetical — it is exactly what happened to `claude/settings.json`
on a routine pull while working on the preceding change.

## Verification

Exercised against a throwaway pair of repositories, having the script genuinely
rewrite itself mid-run rather than only reasoning about it:

| Case | Result |
| --- | --- |
| Autostash conflicts | Aborts, exit 1, deploy never runs |
| Autostash applies cleanly | Deploy runs, body runs, exit 0 |
| Clean tree, script updated by the pull | Re-exec'd into the new version, arguments preserved, exit 0 |
| Not a checkout / git unavailable | Aborts, exit 1 |
| `UPDATE_REEXEC` already set | Skips the refresh entirely, no loop |

`shellcheck` and `shfmt` pass with no reformatting.

## Judgment calls

- **A missing `dotter` warns rather than aborting.** It is mise-managed from
  `mise.toml`, and mise runs later in this same script, so aborting would leave
  a fresh machine unable to bootstrap the tool that fixes it. A `dotter` that
  runs and fails does still abort.
- **The abort is wider than just the autostash case**, covering a missing `git`
  and a `$DOTFILES_DIR` that is not a checkout. Deploying stale configuration
  and upgrading the system regardless seemed the more surprising outcome.
- **Location resolution is deliberately simple**: `~/.dotfiles` by default,
  overridable with `DOTFILES_DIR`. `readlink -f` was avoided because BSD
  `readlink` on macOS only gained `-f` recently and this script has a `brew`
  branch.
- **The existing `####` banner style was kept** rather than switching to
  `# MARK:`, since the other sections use it and restyling them is out of
  scope.
