### PR TITLE
refactor(claude): shrink secondary-review roster

### DIFF
--- a/claude/skills/secondary-review/SKILL.md
+++ b/claude/skills/secondary-review/SKILL.md
@@ -7,7 +7,7 @@ description: Use when implementation work is finished and needs an independent r
 
 ## Overview
 
-An independent review pass run by two populations of reviewers that differ in **what context they are given**, not just what they look for.
+An independent review pass run by two reviewers that differ in **what context they are given**, not just what they look for.
 
 **Core principle:** a reviewer who knows what the change was *supposed* to do grades it against that intent and stops looking. A reviewer who knows nothing judges the code on its own terms. Running both, and reconciling where they disagree, catches what either alone misses.
 
@@ -17,9 +17,9 @@ An independent review pass run by two populations of reviewers that differ in **
 - A PR is open and has forge review comments (Copilot, CodeRabbit, human) to reconcile
 - After a large refactor, when you want a second opinion you didn't author
 
-Prefer `superpowers:requesting-code-review` for a single task inside a plan. Use this when the whole change is done and a missed defect costs more than the fan-out.
+Prefer `superpowers:requesting-code-review` for a single task inside a plan. Use this when the whole change is done and a missed defect costs more than two reviewers.
 
-**Not for:** work in progress, or when you want code *changed* — use `/simplify`.
+**Not for:** work in progress, or when you want code *changed* — use `/simplify`. Also not for a branch that turned out to be several changes at once — see the cohesion gate.
 
 ## The Two Lenses
 
@@ -33,19 +33,27 @@ Prefer `superpowers:requesting-code-review` for a single task inside a plan. Use
 
 ## Roster
 
-| # | Agent | Lens | Aspect |
-|---|---|---|---|
-| B1 | correctness | Blind | Logic errors, edge cases, DRY, patterns |
-| B2 | failure-modes | Blind | Swallowed errors, silent failures |
-| B3 | test-quality | Blind | Real assertions vs mocks and tautologies |
-| B4 | type-design | Blind | Invariants, illegal states representable |
-| B5 | comment-drift | Blind | Comments that no longer match the code |
-| S1 | intent | Sighted | Solves the stated problem? Scope creep? |
-| S2 | coverage | Sighted | Acceptance criteria actually tested? |
-| S3 | doc-consistency | Sighted | Docs and specs this change just made wrong |
-| C | forge | — | Existing PR review comments |
+Two agents, both on Sonnet. One carries the whole blind lens, the other the whole sighted lens.
 
-B2–B5 deliberately do not reuse `pr-review-toolkit`'s equivalent agents: those fetch PR context by design, which defeats the blind lens.
+| Agent | Model | Covers |
+|---|---|---|
+| **Blind** | `sonnet` | correctness, failure-modes, test-quality, type-design, comment-drift |
+| **Sighted** | `sonnet` | intent, coverage, doc-consistency |
+
+Splitting these into one agent per aspect produced findings that mostly overlapped, at one full diff-and-codebase read each. The lens split is what changes findings; the aspect split only multiplied the bill. The aspects survive as checklists inside the two prompts.
+
+Neither reuses `pr-review-toolkit`'s equivalent agents: those fetch PR context by design, which defeats the blind lens.
+
+Forge comments are not an agent. Run `gh pr view --comments` (or the forge equivalent) yourself and reduce it to one line per comment as `file:line — claim`, with no judgement attached.
+
+**Escalation, at most one extra agent.** A deep dive is a second, dedicated pass on an aspect the blind reviewer already covers — depth, not coverage:
+
+- New or modified public types → **type-design**
+- Diff is substantially comments, docstrings, or markdown → **comment-drift**
+
+If both trigger, take the one the diff is more about. Never dispatch both.
+
+Reviewers run on Sonnet, so the confidence filter below is doing real work rather than rubber-stamping. Do not skip it.
 
 ## Scope and Sizing
 
@@ -57,28 +65,33 @@ git diff --stat $BASE..$HEAD | tail -1
 
 For **uncommitted** work, either commit first, or set `[HEAD_SHA]` to the literal string `(working tree)` in the templates — reviewers then use `git diff $BASE` with no second revision.
 
-| Tier | Threshold (both conditions) | Roster |
-|---|---|---|
-| Forge-only | Reconciling existing comments, no fresh review wanted | C, B1 |
-| Focused | ≤ 5 files **and** ≤ 200 changed lines | B1, S1 |
-| Standard | ≤ 20 files **and** ≤ 800 changed lines | B1, B2, B3, S1, S2 |
-| Broad | Anything larger | B1–B5, S1–S3 |
+| Changed lines | Action |
+|---|---|
+| ≤ 1000 | Dispatch. No assessment. |
+| > 1000 | Assess cohesion first — see below. |
 
-Take the first tier whose conditions both hold. Add regardless of tier:
+Reconciling existing forge comments with no fresh review wanted: collect the comments and dispatch the blind reviewer only.
 
-- New or modified public types → **B4**
-- Diff is substantially comments, docstrings, or markdown → **B5**
-- An open PR exists → **C**
+Dispatch selected agents in one message so they run concurrently.
 
-Dispatch every selected agent in one message so they run concurrently.
+## The Cohesion Gate
+
+Above 1000 changed lines, a diff is as likely to be several changes wearing one branch as it is to be a large single change. Reviewing the first kind well is not possible — findings scatter, and the sighted lens has no single intent to review against.
+
+Dispatch one `general-purpose` agent with `model: "haiku"`, giving it **only** `git diff --stat $BASE..$HEAD` and `git log --oneline $BASE..$HEAD`. Not the diff body — the gate must not cost what it is trying to save. Ask it to answer:
+
+- Does this diff do one thing, or several unrelated things?
+- If several: what are they, and which files belong to each?
+
+If it reports one thing, dispatch the normal roster. If it reports several, **stop and do not dispatch**. Report the size, list the split points it named, and ask whether to split the branch or review it anyway. Proceed only on an explicit instruction to review anyway.
+
+A large cohesive diff gets the same two reviewers as a small one. Size is a reason to question the change, not to buy more opinions about it.
 
 ## Dispatch
 
-Blind agents use [blind-reviewer.md](blind-reviewer.md); sighted agents use [sighted-reviewer.md](sighted-reviewer.md).
+The blind reviewer uses [blind-reviewer.md](blind-reviewer.md); the sighted reviewer uses [sighted-reviewer.md](sighted-reviewer.md). Both are dispatched as `general-purpose` with `model: "sonnet"`.
 
-**The blind prompt is the template verbatim with four substitutions: `[ASPECT_NAME]`, `[ASPECT_BRIEF]`, `[BASE_SHA]`, `[HEAD_SHA]`. Nothing is added, no section is inserted, no sentence is rewritten.** The sighted prompt is the template with its eight slots filled.
-
-Agent C needs no template. Run `gh pr view --comments` (or the forge equivalent) and return one line per comment as `file:line — claim`, with no judgement attached.
+**The blind prompt is the template verbatim with three substitutions: `[ASPECTS]`, `[BASE_SHA]`, `[HEAD_SHA]`. Nothing is added, no section is inserted, no sentence is rewritten.** `[ASPECTS]` gets every row of that file's aspect briefs table — all five — unless this is the deep-dive agent, which gets one. The sighted prompt is the template with its seven slots filled, `[ASPECTS]` likewise taking all three rows.
 
 ## Confidence Filter
 
@@ -92,7 +105,7 @@ Reviewers self-score, but **you re-score every finding** before it reaches the u
 | 75 | Verified, will be hit in practice, current approach insufficient |
 | 100 | Confirmed by direct evidence |
 
-Drop below 75. Reviewers are already told to skip compiler-caught, untouched-line, vague, and explicitly-silenced issues; drop any that slip through, plus behaviour changes that are plainly the point of the change.
+Drop below 75. Re-score against the code, not against the reviewer's reasoning — a Sonnet reviewer that argues its way to 75 has still only argued. A finding you cannot reproduce from the diff yourself is a 25. Reviewers are already told to skip compiler-caught, untouched-line, vague, and explicitly-silenced issues; drop any that slip through, plus behaviour changes that are plainly the point of the change.
 
 ## Synthesis
 
@@ -102,7 +115,7 @@ Disagreements do not fall out of the reports — you produce them. Before writin
 
 Group by agreement, not by agent.
 
-1. **Confirmed** — flagged by two or more agents, or scored 100. File:line, what's wrong, why it matters.
+1. **Confirmed** — corroborated by both lenses or by an existing forge comment, or scored 100 on your own re-check. File:line, what's wrong, why it matters. With two reviewers this section is small; that is expected, not a sign the review was thin.
 2. **Disagreements** — from the synthesis step above, with both positions stated. Highest value: a blind finding the context waves away usually means context is doing work the code should do itself; a sighted finding with no code defect behind it usually means a requirement nobody implemented.
 3. **Single-source** — surviving findings from one agent, ranked.
 4. **Forge overlap** — which existing PR comments the reviewers corroborated, and which they contradicted.
@@ -116,6 +129,8 @@ Hand findings to `superpowers:receiving-code-review` — verify before implement
 
 | Mistake | Consequence |
 |---|---|
-| Pasting intent context into a blind prompt "for context" | Collapses two lenses into one; you paid for eight agents and got four |
+| Pasting intent context into a blind prompt "for context" | Collapses two lenses into one; you paid for two reviewers and got one |
 | Giving the sighted reviewer the implementation plan | Findings become "deviates from plan" rather than "is wrong" |
-| Including a simplifier or fixer in the roster | A reviewer that edits invalidates every other reviewer's diff |
+| Including a simplifier or fixer in the roster | A reviewer that edits invalidates the other reviewer's diff |
+| Splitting an aspect out into its own agent "to be thorough" | The aspect is already in the blind prompt; you buy a duplicate diff read and duplicate findings |
+| Reviewing a >1000-line diff that the gate called incoherent | Findings scatter across unrelated changes and the sighted lens has no intent to review against |

--- a/claude/skills/secondary-review/blind-reviewer.md
+++ b/claude/skills/secondary-review/blind-reviewer.md
@@ -1,8 +1,10 @@
 # Blind Reviewer Prompt Template
 
-For agents B1–B5. Dispatch as `general-purpose`, one agent per aspect.
+For the blind reviewer, and for a deep-dive agent when one is warranted. Dispatch as `general-purpose` with `model: "sonnet"`.
 
-Use the template verbatim with four substitutions: `[ASPECT_NAME]`, `[ASPECT_BRIEF]` (from the table below), `[BASE_SHA]`, `[HEAD_SHA]`. Nothing is added, no section is inserted, no sentence is rewritten.
+Use the template verbatim with three substitutions: `[ASPECTS]`, `[BASE_SHA]`, `[HEAD_SHA]`. Nothing is added, no section is inserted, no sentence is rewritten.
+
+Fill `[ASPECTS]` with **every** row of the aspect briefs table below, one per line as `name — brief`. For a deep-dive agent, fill it with that one row instead.
 
 ---
 
@@ -13,11 +15,11 @@ You have not been told what this change is for, what issue it closes, or what
 anyone intended. That is deliberate. Judge the code on its own terms: what it
 actually does, not what it was probably meant to do.
 
-## Your Aspect
+## Your Aspects
 
-[ASPECT_NAME] — [ASPECT_BRIEF]
+[ASPECTS]
 
-Stay in your aspect. Another reviewer is covering the others.
+These are yours in full. Cover each one; do not assume another reviewer has it.
 
 ## The Diff
 
@@ -29,8 +31,10 @@ Head: [HEAD_SHA]
 
 If Head is `(working tree)`, drop it from both commands and diff against Base alone.
 
-Read the surrounding code freely — callers, callees, sibling modules, existing
-tests. You need it to judge whether the diff is correct.
+Read the surrounding code you need to judge the diff — callers, callees, sibling
+modules, existing tests. Follow what the diff touches; do not survey the wider
+repository. If you find yourself reading a file that no changed line reaches,
+stop and go back to the diff.
 
 Read commit *diffs*, not commit *messages*. Do not run `git log` over the range,
 open the issue tracker, open the pull request, or read design documents: those
@@ -73,7 +77,7 @@ For each finding:
 If a finding has no concrete failure scenario, it is a preference. Drop it.
 
 End with:
-- A one-line verdict on this aspect.
+- A one-line verdict per aspect.
 - Discarded candidates, one line each: what you considered and why you dropped
   it. A synthesis step needs these to tell "nobody looked" from "someone looked
   and it was fine".
@@ -86,7 +90,9 @@ to a person — no preamble, no summary of the change, no closing pleasantries.
 
 ## Aspect Briefs
 
-| # | `[ASPECT_NAME]` | `[ASPECT_BRIEF]` |
+Every row goes into `[ASPECTS]`. The numbers survive only so a deep-dive agent and the synthesis step can name one.
+
+| # | Name | Brief |
 |---|---|---|
 | B1 | correctness | Logic errors, off-by-one and boundary bugs, unhandled edge cases, race conditions, duplicated logic that should be shared, patterns that fight the surrounding codebase. |
 | B2 | failure-modes | Errors swallowed or logged-and-continued, fallbacks that mask real failures, unchecked results, `catch`/`unwrap_or_default` that turns a bug into silent wrong behaviour, paths where failure is indistinguishable from success. |

--- a/claude/skills/secondary-review/sighted-reviewer.md
+++ b/claude/skills/secondary-review/sighted-reviewer.md
@@ -1,8 +1,10 @@
 # Sighted Reviewer Prompt Template
 
-For agents S1–S3. Dispatch as `general-purpose`, one agent per aspect.
+For the sighted reviewer. Dispatch as `general-purpose` with `model: "sonnet"`.
 
-**Slots:** `[ASPECT_NAME]`, `[ASPECT_BRIEF]` (from the table below), `[BASE_SHA]`, `[HEAD_SHA]`, `[ISSUE]`, `[PR_DESCRIPTION]`, `[SPEC_REFS]`, `[DOC_REFS]`.
+**Slots:** `[ASPECTS]`, `[BASE_SHA]`, `[HEAD_SHA]`, `[ISSUE]`, `[PR_DESCRIPTION]`, `[SPEC_REFS]`, `[DOC_REFS]`.
+
+Fill `[ASPECTS]` with **every** row of the aspect briefs table below, one per line as `name — brief`.
 
 Leave a slot as `(none provided)` when it doesn't exist. **Never fill any slot with an implementation plan** — see the rule in the template.
 
@@ -15,9 +17,11 @@ Another reviewer is checking whether the code is correct in isolation. That is
 not your job. Yours is the question they structurally cannot ask: given what
 this was supposed to do, does it do it, all of it, and nothing else?
 
-## Your Aspect
+## Your Aspects
 
-[ASPECT_NAME] — [ASPECT_BRIEF]
+[ASPECTS]
+
+These are yours in full. Cover each one.
 
 ## Intent
 
@@ -30,7 +34,8 @@ Specs and requirements: [SPEC_REFS]
 Project documentation: [DOC_REFS]
 
 Read the specs and docs referenced above. Follow references outward as needed —
-a spec that points at another document is telling you to read it.
+a spec that points at another document is telling you to read it. Stop following
+once a reference stops bearing on what this diff changed.
 
 ## Plans Are Not Requirements
 
@@ -87,7 +92,7 @@ A requirement that is satisfied needs no entry. Do not enumerate the
 acceptance criteria and tick them off.
 
 End with:
-- A one-line verdict on this aspect.
+- A one-line verdict per aspect.
 - Discarded candidates, one line each: what you considered and why you dropped
   it. A synthesis step needs these to tell "nobody looked" from "someone looked
   and it was fine".
@@ -100,7 +105,9 @@ to a person.
 
 ## Aspect Briefs
 
-| # | `[ASPECT_NAME]` | `[ASPECT_BRIEF]` |
+Every row goes into `[ASPECTS]`. The numbers survive only so the synthesis step can name one.
+
+| # | Name | Brief |
 |---|---|---|
 | S1 | intent | Whether the change solves the stated problem; requirements stated but not implemented; behaviour implemented that nobody asked for; unrelated changes bundled in; a solution that addresses the symptom described rather than the problem described. |
 | S2 | coverage | Whether each stated acceptance criterion has a test that would fail if that criterion regressed. Name the criterion and the missing test — a bare "needs more tests" is not a finding. |


### PR DESCRIPTION
Three reviewers burned 25% of a five-hour cap in ten minutes, and their findings largely restated one another. Cost scaled with agent count because every agent independently reads the diff and the surrounding code; the narrow aspects bought duplication rather than coverage.

## Changes

**Roster.** The four-tier table (up to eight Opus agents) is replaced by two Sonnet agents: one blind reviewer covering all five blind aspects, one sighted reviewer covering all three. The blind/sighted split is what actually changes findings — a reviewer denied the intent context asks different questions — so it stays; the aspect split becomes checklists inside the two prompts. Forge comments are collected inline instead of by an agent, since that was only ever a shell call and a paste. Escalation is capped at one extra agent and means a *deep dive* on an aspect the blind reviewer already covered, so it adds depth rather than re-treading coverage.

**Cohesion gate.** Diffs at or under 1000 changed lines dispatch unconditionally. Above that, one Haiku agent sees only `--stat` and `--oneline` — never the diff body, so the gate cannot cost what it saves — and reports whether the branch is one change or several. Several means the skill stops, names the split points, and needs an explicit instruction to review anyway. Previously a sprawling branch was rewarded with a larger roster, which is backwards: such a diff should be split, not reviewed harder.

**Confidence filter.** Tightened now that reviewers run on Sonnet: re-score against the code rather than the reviewer's reasoning, and cap anything not reproducible from the diff at 25. This gate is what holds quality with cheaper reviewers, so it is marked as load-bearing.

**Prompts.** `[ASPECT_NAME]`/`[ASPECT_BRIEF]` collapse into one `[ASPECTS]` slot taking every row of each briefs table. Both templates now bound exploration — the blind reviewer stops at files no changed line reaches, the sighted one stops following references that no longer bear on the diff. Unbounded exploration, not prompt size, was the per-agent cost driver.

## Effect

Worst case goes from eight Opus agents to three Sonnet plus one Haiku; the common case is two Sonnet agents.

The **Confirmed** section of the output will be noticeably smaller, since corroboration now means agreement across the two lenses rather than between five near-identical blind agents. That is called out inline so it does not read as a thin review.