### PR TITLE
feat(gpg): supervise gpg-agent with launchd on macOS

### DIFF
--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -29,9 +29,10 @@
 
 [bin]
   [bin.files]
-  "bin/pinentry-auto"  = "~/.local/bin/pinentry-auto"
-  "bin/transcode-hevc" = "~/.local/bin/transcode-hevc"
-  "bin/update"         = "~/.local/bin/update"
+  "bin/gpg-agent-launchd" = { target = "~/.local/bin/gpg-agent-launchd", type = "symbolic", if = "dotter.macos" }
+  "bin/pinentry-auto"     = "~/.local/bin/pinentry-auto"
+  "bin/transcode-hevc"    = "~/.local/bin/transcode-hevc"
+  "bin/update"            = "~/.local/bin/update"
 
 [borgmatic]
   [borgmatic.files]
@@ -94,10 +95,14 @@
   "gpg/gpg-agent.conf" = "~/.local/share/gnupg/gpg-agent.conf"
   "gpg/sshcontrol"     = "~/.local/share/gnupg/sshcontrol"
 
-  "gpg/systemd/gpg-agent-browser.socket.conf" = "~/.config/systemd/user/gpg-agent-browser.socket.d/gnupghome.conf"
-  "gpg/systemd/gpg-agent-extra.socket.conf"   = "~/.config/systemd/user/gpg-agent-extra.socket.d/gnupghome.conf"
-  "gpg/systemd/gpg-agent-ssh.socket.conf"     = "~/.config/systemd/user/gpg-agent-ssh.socket.d/gnupghome.conf"
-  "gpg/systemd/gpg-agent.socket.conf"         = "~/.config/systemd/user/gpg-agent.socket.d/gnupghome.conf"
+  ## Service manager integration: systemd user units on Linux, a LaunchAgent on
+  ## macOS. Windows has no gpg-agent supervision here yet.
+  "gpg/systemd/gpg-agent-browser.socket.conf" = { target = "~/.config/systemd/user/gpg-agent-browser.socket.d/gnupghome.conf", type = "symbolic", if = "dotter.linux" }
+  "gpg/systemd/gpg-agent-extra.socket.conf"   = { target = "~/.config/systemd/user/gpg-agent-extra.socket.d/gnupghome.conf", type = "symbolic", if = "dotter.linux" }
+  "gpg/systemd/gpg-agent-ssh.socket.conf"     = { target = "~/.config/systemd/user/gpg-agent-ssh.socket.d/gnupghome.conf", type = "symbolic", if = "dotter.linux" }
+  "gpg/systemd/gpg-agent.socket.conf"         = { target = "~/.config/systemd/user/gpg-agent.socket.d/gnupghome.conf", type = "symbolic", if = "dotter.linux" }
+
+  "gpg/launchd/me.jpellis.gpg-agent.plist" = { target = "~/Library/LaunchAgents/me.jpellis.gpg-agent.plist", type = "symbolic", if = "dotter.macos" }
 
 [kitty]
   [kitty.files]

--- a/.dotter/post_deploy.sh
+++ b/.dotter/post_deploy.sh
@@ -35,3 +35,34 @@ link_dir() {
 link_dir \
   "claude/skills/diataxis/diataxis-documentation-framework" \
   "$HOME/.claude/skills/diataxis/diataxis-documentation-framework"
+
+# MARK: macOS gpg-agent LaunchAgent
+# Registers the LaunchAgent deployed by the `macos` package, and retires Apple's
+# ssh-agent job. The latter matters because it declares its socket with
+# SecureSocketWithKey, so launchd stamps SSH_AUTH_SOCK across the whole login
+# session and races whatever gpg-agent publishes. Keychain-backed ssh keys go
+# away with it; gpg-agent holds the keys here instead.
+#
+# Only `disable` is used: SIP forbids booting out a system LaunchAgent, so the
+# already-running instance survives until the next login. That is harmless —
+# the LaunchAgent's own `launchctl setenv` takes precedence in the meantime.
+
+bootstrap_gpg_agent() {
+  local plist domain
+  plist="$HOME/Library/LaunchAgents/me.jpellis.gpg-agent.plist"
+  domain="gui/$(id -u)"
+
+  [ "$(uname -s)" = "Darwin" ] || return 0
+  if [ ! -f "$plist" ]; then
+    echo "post_deploy: $plist not deployed; skipping LaunchAgent bootstrap" >&2
+    return 0
+  fi
+
+  launchctl disable "$domain/com.openssh.ssh-agent" 2>/dev/null || true
+
+  # Re-bootstrap so an edited plist takes effect without a logout.
+  launchctl bootout "$domain/me.jpellis.gpg-agent" 2>/dev/null || true
+  launchctl bootstrap "$domain" "$plist"
+}
+
+bootstrap_gpg_agent

--- a/bin/gpg-agent-launchd
+++ b/bin/gpg-agent-launchd
@@ -1,0 +1,37 @@
+#!/bin/sh
+## Login job for gpg-agent on macOS, started by launchd (me.jpellis.gpg-agent).
+##
+## There is no launchd counterpart to systemd socket activation here:
+## `gpg-agent --supervised` expects sockets over sd_listen_fds, which launchd
+## cannot speak, so the agent is started eagerly instead.  Eager start matters
+## because gpg-agent only auto-spawns for the gpg binary — an ssh client
+## connecting to a socket with no agent behind it just fails.
+##
+## launchd sources neither ~/.profile nor ~/.config/environment.d, so GNUPGHOME
+## is re-derived here; without it gpgconf would act on the default ~/.gnupg.
+set -eu
+
+GNUPGHOME="${GNUPGHOME:-${XDG_DATA_HOME:-$HOME/.local/share}/gnupg}"
+export GNUPGHOME
+
+gpgconf=""
+for dir in /opt/homebrew/bin /usr/local/bin /usr/bin; do
+  if [ -x "$dir/gpgconf" ]; then
+    gpgconf="$dir/gpgconf"
+    break
+  fi
+done
+
+if [ -z "$gpgconf" ]; then
+  echo "gpg-agent-launchd: no gpgconf found" >&2
+  exit 0
+fi
+
+"$gpgconf" --launch gpg-agent
+
+## Publish the socket into the launchd user domain so GUI applications, which
+## never read the shell config, still reach gpg-agent.  This only holds while
+## Apple's com.openssh.ssh-agent is disabled — its SecureSocketWithKey socket
+## declaration re-stamps SSH_AUTH_SOCK across the whole session and would
+## otherwise take precedence.
+/bin/launchctl setenv SSH_AUTH_SOCK "$("$gpgconf" --list-dirs agent-ssh-socket)"

--- a/general/sshconfig
+++ b/general/sshconfig
@@ -7,6 +7,15 @@ Host *
     ControlMaster auto
     ControlPath {{#if tmpdir}}{{tmpdir}}{{else}}/tmp{{/if}}/ssh-%C.socket
     ControlPersist 30m
+{{#if dotter.macos}}
+
+    ## macOS: launchd's com.openssh.ssh-agent stamps SSH_AUTH_SOCK into every
+    ## session from its own socket, so pointing ssh at gpg-agent explicitly is
+    ## more reliable than hoping the variable survives.  On Linux the systemd
+    ## user manager publishes the socket itself — see
+    ## gpg/systemd/gpg-agent-ssh.socket.conf.
+    IdentityAgent ~/.local/share/gnupg/S.gpg-agent.ssh
+{{/if}}
 
 ## Personal
 ################################################################################

--- a/gpg/launchd/me.jpellis.gpg-agent.plist
+++ b/gpg/launchd/me.jpellis.gpg-agent.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>me.jpellis.gpg-agent</string>
+
+  <!-- Wrapped in a shell so $HOME resolves; launchd does not expand it in
+       ProgramArguments. -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>-c</string>
+    <string>exec "$HOME/.local/bin/gpg-agent-launchd"</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <!-- A login job that fails is otherwise silent. -->
+  <key>StandardOutPath</key>
+  <string>/tmp/me.jpellis.gpg-agent.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/me.jpellis.gpg-agent.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Why

macOS ships `com.openssh.ssh-agent`, a LaunchAgent whose socket is declared with `SecureSocketWithKey: SSH_AUTH_SOCK`. That makes launchd stamp `SSH_AUTH_SOCK` into every process in the login session, overriding whatever gpg-agent publishes — which is why a manual `ln -sf` of gpg's socket over Apple's was needed after each login. That habit is fragile: a symlink created in the wrong direction had left `S.gpg-agent.ssh` pointing at itself, silently breaking ssh authentication entirely.

Linux already gets proper supervision from the systemd user units in `gpg/systemd/`. This gives macOS the equivalent.

## What

- **`gpg/launchd/me.jpellis.gpg-agent.plist`** — LaunchAgent that runs at login. There is no launchd counterpart to systemd socket activation (`gpg-agent --supervised` speaks `sd_listen_fds`, which launchd cannot feed), so the agent is started eagerly. That matters because gpg-agent only auto-spawns for the `gpg` binary; an ssh client hitting a dead socket just fails.
- **`bin/gpg-agent-launchd`** — what the job runs. Re-derives `GNUPGHOME` because launchd reads neither `~/.profile` nor `~/.config/environment.d`, then publishes the socket with `launchctl setenv` for GUI apps.
- **`general/sshconfig`** — `IdentityAgent` on macOS, so `ssh(1)` reaches gpg-agent regardless of the environment. This is the layer that makes git/VSCode/Emacs work even if `SSH_AUTH_SOCK` is wrong.
- **`.dotter/post_deploy.sh`** — bootstraps the LaunchAgent and disables Apple's ssh-agent. Only `disable` is used: SIP forbids booting out a system LaunchAgent, so the running instance survives until next login, which is harmless since `setenv` takes precedence meanwhile. Keychain-backed ssh keys go away with it; gpg-agent holds the keys here.

## Per-OS selection

Rather than a separate `macos` package, service-manager files are selected with dotter's OS conditionals, so a new machine of either kind gets the right half without editing the gitignored `local.toml`:

```toml
"gpg/systemd/gpg-agent-ssh.socket.conf"   = { …, type = "symbolic", if = "dotter.linux" }
"gpg/launchd/me.jpellis.gpg-agent.plist"  = { …, type = "symbolic", if = "dotter.macos" }
```

`if` is only valid on complex entries, which require an explicit `type`; `symbolic` matches what dotter's auto-detection was already doing for these files. Windows needs no entry.

This also fixed a latent bug: the systemd drop-ins had been deploying into `~/.config/systemd/user/` on macOS, where nothing reads them.

## Verification

```
$ env -u SSH_AUTH_SOCK ssh -T git@github.com
Hi JP-Ellis! You've successfully authenticated…

$ SSH_AUTH_SOCK=/nonexistent/sock ssh -T git@github.com
Hi JP-Ellis! You've successfully authenticated…

$ launchctl getenv SSH_AUTH_SOCK
/Users/joshua.ellis/.local/share/gnupg/S.gpg-agent.ssh
```

Both layers confirmed independently. `dotter deploy` applied cleanly; shellcheck, shfmt, `plutil -lint` and tombi all pass.