### PR TITLE
chore(dotter): drop the TOML 1.0 pin on the dotter config

### DIFF
--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -1,5 +1,3 @@
-#:tombi toml-version = "v1.0.0"
-
 [default]
   [default.variables]
   app-browser = "brave"
@@ -21,7 +19,10 @@
   "claude/CLAUDE.md"                  = "~/.claude/CLAUDE.md"
   "claude/RTK.md"                     = "~/.claude/RTK.md"
   "claude/rules"                      = "~/.claude/rules"
-  "claude/settings.json"              = { target = "~/.claude/settings.json", type = "symbolic" }
+  "claude/settings.json"              = {
+    target = "~/.claude/settings.json",
+    type   = "symbolic"
+  }
   "claude/skills/secondary-review"    = "~/.claude/skills/secondary-review"
   "claude/skills/diataxis/SKILL.md"   = "~/.claude/skills/diataxis/SKILL.md"
   "claude/skills/diataxis/evals"      = "~/.claude/skills/diataxis/evals"
@@ -29,7 +30,11 @@
 
 [bin]
   [bin.files]
-  "bin/gpg-agent-launchd" = { target = "~/.local/bin/gpg-agent-launchd", type = "symbolic", if = "dotter.macos" }
+  "bin/gpg-agent-launchd" = {
+    target = "~/.local/bin/gpg-agent-launchd",
+    type   = "symbolic",
+    if     = "dotter.macos"
+  }
   "bin/pinentry-auto"     = "~/.local/bin/pinentry-auto"
   "bin/transcode-hevc"    = "~/.local/bin/transcode-hevc"
   "bin/update"            = "~/.local/bin/update"
@@ -97,12 +102,32 @@
 
   ## Service manager integration: systemd user units on Linux, a LaunchAgent on
   ## macOS. Windows has no gpg-agent supervision here yet.
-  "gpg/systemd/gpg-agent-browser.socket.conf" = { target = "~/.config/systemd/user/gpg-agent-browser.socket.d/gnupghome.conf", type = "symbolic", if = "dotter.linux" }
-  "gpg/systemd/gpg-agent-extra.socket.conf"   = { target = "~/.config/systemd/user/gpg-agent-extra.socket.d/gnupghome.conf", type = "symbolic", if = "dotter.linux" }
-  "gpg/systemd/gpg-agent-ssh.socket.conf"     = { target = "~/.config/systemd/user/gpg-agent-ssh.socket.d/gnupghome.conf", type = "symbolic", if = "dotter.linux" }
-  "gpg/systemd/gpg-agent.socket.conf"         = { target = "~/.config/systemd/user/gpg-agent.socket.d/gnupghome.conf", type = "symbolic", if = "dotter.linux" }
+  "gpg/systemd/gpg-agent-browser.socket.conf" = {
+    target = "~/.config/systemd/user/gpg-agent-browser.socket.d/gnupghome.conf",
+    type   = "symbolic",
+    if     = "dotter.linux"
+  }
+  "gpg/systemd/gpg-agent-extra.socket.conf"   = {
+    target = "~/.config/systemd/user/gpg-agent-extra.socket.d/gnupghome.conf",
+    type   = "symbolic",
+    if     = "dotter.linux"
+  }
+  "gpg/systemd/gpg-agent-ssh.socket.conf"     = {
+    target = "~/.config/systemd/user/gpg-agent-ssh.socket.d/gnupghome.conf",
+    type   = "symbolic",
+    if     = "dotter.linux"
+  }
+  "gpg/systemd/gpg-agent.socket.conf"         = {
+    target = "~/.config/systemd/user/gpg-agent.socket.d/gnupghome.conf",
+    type   = "symbolic",
+    if     = "dotter.linux"
+  }
 
-  "gpg/launchd/me.jpellis.gpg-agent.plist" = { target = "~/Library/LaunchAgents/me.jpellis.gpg-agent.plist", type = "symbolic", if = "dotter.macos" }
+  "gpg/launchd/me.jpellis.gpg-agent.plist" = {
+    target = "~/Library/LaunchAgents/me.jpellis.gpg-agent.plist",
+    type   = "symbolic",
+    if     = "dotter.macos"
+  }
 
 [kitty]
   [kitty.files]
@@ -118,7 +143,10 @@
 
 [mathematica]
   [mathematica.files]
-  "Mathematica/Kernel.m" = { target = "~/.config/mathematica/Kernel/init.m", type = "symbolic" }
+  "Mathematica/Kernel.m" = {
+    target = "~/.config/mathematica/Kernel/init.m",
+    type   = "symbolic"
+  }
 
 [mise]
   [mise.files]
@@ -165,6 +193,9 @@
   "zsh/zshrc"                  = "~/.config/zsh/.zshrc"
   "zsh/zstyles"                = "~/.config/zsh/zstyles"
   "zsh/conf.d"                 = "~/.config/zsh/conf.d"
-  "zsh/sheldon.toml"           = { target = "~/.config/sheldon/plugins.toml", type = "symbolic" }
+  "zsh/sheldon.toml"           = {
+    target = "~/.config/sheldon/plugins.toml",
+    type   = "symbolic"
+  }
   "zsh/sheldon-update.service" = "~/.config/systemd/user/sheldon-update.service"
   "zsh/sheldon-update.timer"   = "~/.config/systemd/user/sheldon-update.timer"

--- a/.dotter/post_deploy.sh
+++ b/.dotter/post_deploy.sh
@@ -37,7 +37,7 @@ link_dir \
   "$HOME/.claude/skills/diataxis/diataxis-documentation-framework"
 
 # MARK: macOS gpg-agent LaunchAgent
-# Registers the LaunchAgent deployed by the `macos` package, and retires Apple's
+# Registers the LaunchAgent deployed by the `gpg` package, and retires Apple's
 # ssh-agent job. The latter matters because it declares its socket with
 # SecureSocketWithKey, so launchd stamps SSH_AUTH_SOCK across the whole login
 # session and races whatever gpg-agent publishes. Keychain-backed ssh keys go


### PR DESCRIPTION
## Summary

`.dotter/global.toml` carried a per-file `#:tombi toml-version = "v1.0.0"` override because dotter's parser could not read TOML 1.1's multi-line inline tables. It can now, so the file follows the repo-wide 1.1 setting in `.tombi.toml` and the conditional entries wrap instead of running long.

Also corrects a stale comment in `post_deploy.sh` that still referred to the `macos` package removed in #260.

## Verification

- dotter is at 0.13.5, the latest on crates.io; confirmed against an isolated fixture that it parses a multi-line inline table (with and without a trailing comma).
- `tombi format` + `tombi lint` clean on the reformatted file.
- `dotter deploy --dry-run` exits 0 with no diff. Verified that is a real pass and not silence: a deliberately malformed entry makes the same command exit 1 with a parse error.
- All prek hooks pass.

No deployment behaviour changes — the parsed config is identical.