### PR TITLE
feat(gpg): let Emacs drive pinentry through gpg-agent

### DIFF
--- a/doom/config.org
+++ b/doom/config.org
@@ -26,6 +26,15 @@ various templates or snippets.
 (setq user-full-name "{{ username }}"
       user-mail-address "{{ email }}")
 #+end_src
+** GPG
+Explicitly set ~GNUPGHOME~ so subprocesses (git, gpg) always use the correct
+keyring regardless of env file loading order. GPG 2.5+ creates ~~/.gnupg~ with
+~use-keyboxd~ enabled; without this, any subprocess that inherits a missing
+~GNUPGHOME~ falls back to that empty keybox and reports "No secret key".
+#+begin_src emacs-lisp
+(setenv "GNUPGHOME" (expand-file-name "~/.local/share/gnupg"))
+(setq epa-pinentry-mode 'loopback)
+#+end_src
 * Display
 Change the visual appearance of Doom Emacs
 ** Font

--- a/gpg/gpg-agent.conf
+++ b/gpg/gpg-agent.conf
@@ -2,6 +2,7 @@ max-cache-ttl 7200
 default-cache-ttl 7200
 default-cache-ttl-ssh 7200
 enable-ssh-support
+allow-loopback-pinentry
 
 {{#if (is_executable "/opt/homebrew/bin/pinentry-mac") }}
 pinentry-program /opt/homebrew/bin/pinentry-mac


### PR DESCRIPTION
## Summary

Doom runs `gpg` in-process for signing and decryption, where a graphical pinentry has no way to reach the user. `allow-loopback-pinentry` in `gpg-agent.conf` plus `epa-pinentry-mode 'loopback` keeps the prompt inside Emacs.

Doom also sets `GNUPGHOME` explicitly rather than relying on the environment reaching it. GPG 2.5 creates a keyboxd-backed `~/.gnupg` on first use, so a subprocess that inherits an unset `GNUPGHOME` silently finds an empty keyring and reports "No secret key" instead of failing in an obvious way.

Also carries a diataxis submodule digest bump.

## Notes

`.vscode/settings.json` is left untracked on purpose — it holds absolute paths into this machine's mise installs.